### PR TITLE
Full response for query, problems in SdkError

### DIFF
--- a/src/query/queryApi.test.ts
+++ b/src/query/queryApi.test.ts
@@ -49,7 +49,6 @@ describe('QueryApi', () => {
       columns: [[111]],
     },
   ];
-  const expectedOutput = [mockOutput[0]];
   const database = 'test-db';
   const engine = 'test-engine';
 
@@ -97,7 +96,7 @@ describe('QueryApi', () => {
 
     scope.done();
 
-    expect(result).toEqual(expectedOutput);
+    expect(result).toEqual(response);
   });
 
   it('should query with inputs', async () => {
@@ -153,7 +152,7 @@ describe('QueryApi', () => {
 
     scope.done();
 
-    expect(result).toEqual(expectedOutput);
+    expect(result).toEqual(response);
   });
 
   it('should load json', async () => {
@@ -212,7 +211,7 @@ describe('QueryApi', () => {
 
     scope.done();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(response);
   });
 
   it('should load csv', async () => {
@@ -270,7 +269,7 @@ describe('QueryApi', () => {
 
     scope.done();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(response);
   });
 
   it('should load csv with syntax', async () => {
@@ -342,7 +341,7 @@ describe('QueryApi', () => {
 
     scope.done();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(response);
   });
 
   it('should load csv with schema', async () => {
@@ -412,6 +411,6 @@ describe('QueryApi', () => {
 
     scope.done();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(response);
   });
 });

--- a/src/query/queryApi.ts
+++ b/src/query/queryApi.ts
@@ -29,13 +29,8 @@ export class QueryApi extends TransactionApi {
     readonly = true,
   ) {
     const action = makeQueryAction(queryString, inputs);
-    const result = await this.runActions(database, engine, [action], readonly);
 
-    if (result.actions[0]?.result?.type === 'QueryActionResult') {
-      return result.output.filter(r => r.rel_key.name === 'output');
-    }
-
-    throw new Error('QueryActionResult is missing');
+    return await this.runActions(database, engine, [action], readonly);
   }
 
   async loadJson(


### PR DESCRIPTION
- Now `client.query` returns full `TransactionResult`, not just the `output` portion of it. Otherwise, there's no way to get `problems` and the other fields.
- Just realized that an http call can get non 200 response and no `{ "message": "blah" }` in the body. For example: 422 on the transaction endpoint. In such cases it'll add `problems` to the error object and a generic error message.

Note: we can separate SdkError into to separate errors. Not sure about it at the moment.
