### PR TITLE
Empty path models as a query

### DIFF
--- a/src/model/modelUtils.ts
+++ b/src/model/modelUtils.ts
@@ -16,12 +16,12 @@
 
 import { Model } from '../transaction/types';
 
-export function makeModel(name: string, value: string) {
+export function makeModel(name: string, value: string, path = name) {
   const model: Model = {
     type: 'Source',
     name,
     value,
-    path: name,
+    path,
   };
 
   return model;

--- a/src/query/queryApi.test.ts
+++ b/src/query/queryApi.test.ts
@@ -65,7 +65,7 @@ describe('QueryApi', () => {
           inputs: [],
           source: {
             type: 'Source',
-            path: 'query',
+            path: '',
             value: 'def output = 123',
             name: 'query',
           },
@@ -120,7 +120,7 @@ describe('QueryApi', () => {
           ],
           source: {
             type: 'Source',
-            path: 'query',
+            path: '',
             value: 'def output = 123',
             name: 'query',
           },
@@ -176,7 +176,7 @@ describe('QueryApi', () => {
           ],
           source: {
             type: 'Source',
-            path: 'query',
+            path: '',
             value: [
               'def config:data = data',
               'def insert:test_relation = load_json[config]',
@@ -236,7 +236,7 @@ describe('QueryApi', () => {
           ],
           source: {
             type: 'Source',
-            path: 'query',
+            path: '',
             value: [
               'def config:data = data',
               'def insert:test_relation = load_csv[config]',
@@ -294,7 +294,7 @@ describe('QueryApi', () => {
           ],
           source: {
             type: 'Source',
-            path: 'query',
+            path: '',
             value: [
               'def config:data = data',
               'def config:syntax:header = (1, "foo"); (2, "bar")',
@@ -366,7 +366,7 @@ describe('QueryApi', () => {
           ],
           source: {
             type: 'Source',
-            path: 'query',
+            path: '',
             value: [
               'def config:data = data',
               'def config:schema:foo = "int"',

--- a/src/query/queryUtils.ts
+++ b/src/query/queryUtils.ts
@@ -26,7 +26,7 @@ export function makeQueryAction(
     type: 'QueryAction',
     outputs: [],
     persist: [],
-    source: makeModel('query', queryString),
+    source: makeModel('query', queryString, ''),
     inputs: inputs.map(input => makeQueryInput(input.name, input.value)),
   };
 


### PR DESCRIPTION
Handling problems usually have a check like `problem.path === ''`  to filter out problems that aren't related to the query.