### PR TITLE
Fixed inputs in v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@relationalai/rai-sdk-javascript",
   "description": "RelationalAI SDK for JavaScript",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": {
     "name": "RelationalAI",
     "url": "https://relational.ai"

--- a/src/query/execAsyncApi.test.ts
+++ b/src/query/execAsyncApi.test.ts
@@ -43,7 +43,7 @@ describe('QueryAsyncApi', () => {
         query: query,
         nowait_durable: false,
         readonly: true,
-        inputs: [],
+        v1_inputs: [],
       })
       .reply(200, response);
     const result = await api.execAsync(database, engine, query, [], true);

--- a/src/query/execAsyncApi.ts
+++ b/src/query/execAsyncApi.ts
@@ -39,7 +39,7 @@ export class ExecAsyncApi extends TransactionAsyncApi {
       query: queryString,
       nowait_durable: false,
       readonly,
-      inputs: inputs.map(input => makeQueryInput(input.name, input.value)),
+      v1_inputs: inputs.map(input => makeQueryInput(input.name, input.value)),
     };
 
     if (engine) {

--- a/src/transaction/transactionAsyncApi.test.ts
+++ b/src/transaction/transactionAsyncApi.test.ts
@@ -64,7 +64,7 @@ describe('TransactionAsyncApi', () => {
       query: query,
       nowait_durable: false,
       readonly: true,
-      inputs: [],
+      v1_inputs: [],
     };
     const scope = nock(baseUrl).post(path, payload).reply(200, response);
     const result = await api.runTransactionAsync(payload);
@@ -82,7 +82,7 @@ describe('TransactionAsyncApi', () => {
       query: query,
       nowait_durable: false,
       readonly: true,
-      inputs: [],
+      v1_inputs: [],
     };
     const scope = nock(baseUrl).post(path, payload).reply(200, multipartMock, {
       'Content-type': multopartContentType,

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -177,7 +177,7 @@ export type TransactionAsyncPayload = {
   readonly: boolean;
   engine_name?: string;
   query: string;
-  inputs: Relation[];
+  v1_inputs: Relation[];
 };
 
 export type TransactionAsync = {


### PR DESCRIPTION
Just found out that inputs don't work in v2. I thought I tested it when I was adding `.execAsync`.  Probably it got changed to `v1_inputs` later.    