### PR TITLE
Fix unhandled exception in pollTransaction

### DIFF
--- a/src/api/query/execAsyncApi.ts
+++ b/src/api/query/execAsyncApi.ts
@@ -93,7 +93,10 @@ export class ExecAsyncApi extends TransactionAsyncApi {
     await new Promise<void>((resolve, reject) => {
       const checkState = () => {
         setTimeout(async () => {
-          transaction = await this.getTransaction(txnId);
+          try {
+            transaction = await this.getTransaction(txnId);
+            // eslint-disable-next-line no-empty
+          } catch {}
 
           if (isTransactionDone(transaction.state)) {
             resolve();


### PR DESCRIPTION
If you have a network error during the polling, it results into an unhandled exception because it happens in a setTimeout. The polling still continues, it's just that you see an unhandled exception in the dev tools.

`try/catch` doesn't change the existing behavior