### PR TITLE
v1 query fix

### DIFF
--- a/src/api/model/modelUtils.ts
+++ b/src/api/model/modelUtils.ts
@@ -15,16 +15,6 @@
  */
 
 import { RelationId } from '../../proto/generated/schema';
-import { Model } from '../transaction/types';
-
-export function makeModel(name: string, value: string) {
-  const model: Model = {
-    name,
-    value,
-  };
-
-  return model;
-}
 
 // gets the model output name from protobuf
 export function getModelOutputFromProto(relationId: RelationId) {

--- a/src/api/query/queryApi.test.ts
+++ b/src/api/query/queryApi.test.ts
@@ -66,6 +66,7 @@ describe('QueryApi', () => {
           source: {
             value: 'def output = 123',
             name: 'query',
+            type: 'Source',
           },
         },
       ],
@@ -119,6 +120,7 @@ describe('QueryApi', () => {
           source: {
             value: 'def output = 123',
             name: 'query',
+            type: 'Source',
           },
         },
       ],
@@ -171,6 +173,7 @@ describe('QueryApi', () => {
             },
           ],
           source: {
+            type: 'Source',
             value: [
               'def config:data = data',
               'def insert:test_relation = load_json[config]',
@@ -229,6 +232,7 @@ describe('QueryApi', () => {
             },
           ],
           source: {
+            type: 'Source',
             value: [
               'def config:data = data',
               'def insert:test_relation = load_csv[config]',
@@ -285,6 +289,7 @@ describe('QueryApi', () => {
             },
           ],
           source: {
+            type: 'Source',
             value: [
               'def config:data = data',
               'def config:syntax:header = (1, "foo"); (2, "bar")',
@@ -355,6 +360,7 @@ describe('QueryApi', () => {
             },
           ],
           source: {
+            type: 'Source',
             value: [
               'def config:data = data',
               'def config:schema:foo = "int"',

--- a/src/api/query/queryUtils.ts
+++ b/src/api/query/queryUtils.ts
@@ -14,7 +14,6 @@
  * under the License.
  */
 
-import { makeModel } from '../model/modelUtils';
 import { QueryAction, Relation, RelValue } from '../transaction/types';
 import { QueryInput } from './types';
 
@@ -26,7 +25,11 @@ export function makeQueryAction(
     type: 'QueryAction',
     outputs: [],
     persist: [],
-    source: makeModel('query', queryString),
+    source: {
+      type: 'Source',
+      name: 'query',
+      value: queryString,
+    },
     inputs: inputs.map(input => makeQueryInput(input.name, input.value)),
   };
 

--- a/src/api/transaction/types.ts
+++ b/src/api/transaction/types.ts
@@ -38,6 +38,13 @@ export type Model = {
   value: string;
 };
 
+export type ModelV1 = {
+  name: string;
+  value: string;
+  type: 'Source';
+  path?: string;
+};
+
 export type IntegrityConstraintViolation = {
   type: 'IntegrityConstraintViolation';
   sources: {
@@ -86,7 +93,7 @@ export type QueryAction = {
   inputs: Relation[];
   outputs: string[];
   persist: string[];
-  source: Model;
+  source: ModelV1;
 };
 
 export type QueryActionResult = {
@@ -107,7 +114,7 @@ export type ModifyWorkspaceActionResult = {
 
 export type InstallAction = {
   type: 'InstallAction';
-  sources: Model[];
+  sources: ModelV1[];
 };
 
 export type InstallActionResult = {
@@ -120,7 +127,7 @@ export type ListSourceAction = {
 
 export type ListSourceActionResult = {
   type: 'ListSourceActionResult';
-  sources: Model[];
+  sources: ModelV1[];
 };
 
 export type ListEdbAction = {


### PR DESCRIPTION
`client.query` always triggers a 400 now because `type` property is missing. It was removed in https://github.com/RelationalAI/rai-sdk-javascript/pull/52

I just created a separate `ModelV1` type to fix it. We'll get rid of it with the rest of the v1 stuff. 