### PR TITLE
Removed test

### DIFF
--- a/src/results/tests.ts
+++ b/src/results/tests.ts
@@ -2630,38 +2630,6 @@ export const miscValueTypeTests: Test[] = [
     values: [[':Foo', ':Bar', ':MyType', 12n, 34n]],
     displayValues: ['(:Foo, :Bar, :MyType, 12, 34)'],
   },
-  {
-    name: 'Missing',
-    query: `
-      value type MyType = Int, Missing, Int
-      def v = ^MyType[1, missing, 2]
-      def output = #(v)
-    `,
-    typeDefs: [
-      {
-        type: 'Constant',
-        value: {
-          type: 'ValueType',
-          typeDefs: [
-            {
-              type: 'Int64',
-            },
-            {
-              type: 'Missing',
-            },
-            {
-              type: 'Int64',
-            },
-          ],
-          value: [1n, null, 2n],
-        },
-      },
-    ],
-    // TODO this should be [":MyType", 1n, null, 2n] really
-    // move this down to valueTypeSpecializationTests when specialization is fixed
-    values: [[1n, null, 2n]],
-    displayValues: ['(1, missing, 2)'],
-  },
 ];
 
 // TODO uncomment this when specialization on value types isfixed


### PR DESCRIPTION
Removing because the expected value is not right. It factors in the fact that there's another bug.

Fixes: https://github.com/RelationalAI/rai-sdk-javascript/issues/66

It'd be covered in `valueTypeSpecializationTests` tests when we enable them.