### PR TITLE
RAI-15919 fix decimal128 precision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@relationalai/rai-sdk-javascript",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@relationalai/rai-sdk-javascript",
-  "version": "0.7.1",
+  "version": "0.7.2-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@relationalai/rai-sdk-javascript",
   "description": "RelationalAI SDK for JavaScript",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "RelationalAI",
     "url": "https://relational.ai"

--- a/src/results/resultTable.test.ts
+++ b/src/results/resultTable.test.ts
@@ -16,7 +16,6 @@
 
 import { tableFromArrays } from 'apache-arrow';
 import { Table as PrintTable } from 'console-table-printer';
-import Decimal from 'decimal.js';
 
 import { ArrowRelation } from '../api/transaction/types';
 import { MetadataInfo } from '../proto/generated/message';
@@ -35,23 +34,12 @@ function makeMetadata(json: any) {
 }
 
 describe('ResultTable', () => {
-  const MAX_INT_64 = 9223372036854775807n;
-  const MAX_DEC_128 = new Decimal(
-    '1.70141183460469231722463931679029329919e+28',
-  );
   const relation: ArrowRelation = {
-    relationId:
-      '/Int64(1)/:foo/String/:bar/Char/Int64/FixedPointDecimals.FixedDecimal{Int128, 10}',
+    relationId: '/Int64(1)/:foo/String/:bar/Char/Int64',
     table: tableFromArrays({
       v1: ['w', 'x', 'y', 'z'],
       v2: [97, 98, 99, 100],
       v3: [1n, 2n, 3n, 4n],
-      v4: [
-        [MAX_INT_64, MAX_INT_64],
-        [MAX_INT_64, MAX_INT_64],
-        [MAX_INT_64, MAX_INT_64],
-        [MAX_INT_64, MAX_INT_64],
-      ],
     }),
     metadata: makeMetadata({
       arguments: [
@@ -118,106 +106,9 @@ describe('ResultTable', () => {
           tag: 'PRIMITIVE_TYPE',
           primitiveType: 'INT_64',
         },
-        {
-          tag: 'VALUE_TYPE',
-          valueType: {
-            argumentTypes: [
-              {
-                tag: 'CONSTANT_TYPE',
-                constantType: {
-                  relType: {
-                    tag: 'PRIMITIVE_TYPE',
-                    primitiveType: 'STRING',
-                  },
-                  value: {
-                    arguments: [
-                      {
-                        tag: 'STRING',
-                        stringVal: 'cmVs',
-                      },
-                    ],
-                  },
-                },
-              },
-              {
-                tag: 'CONSTANT_TYPE',
-                constantType: {
-                  relType: {
-                    tag: 'PRIMITIVE_TYPE',
-                    primitiveType: 'STRING',
-                  },
-                  value: {
-                    arguments: [
-                      {
-                        tag: 'STRING',
-                        stringVal: 'YmFzZQ==',
-                      },
-                    ],
-                  },
-                },
-              },
-              {
-                tag: 'CONSTANT_TYPE',
-                constantType: {
-                  relType: {
-                    tag: 'PRIMITIVE_TYPE',
-                    primitiveType: 'STRING',
-                  },
-                  value: {
-                    arguments: [
-                      {
-                        tag: 'STRING',
-                        stringVal: 'Rml4ZWREZWNpbWFs',
-                      },
-                    ],
-                  },
-                },
-              },
-              {
-                tag: 'CONSTANT_TYPE',
-                constantType: {
-                  relType: {
-                    tag: 'PRIMITIVE_TYPE',
-                    primitiveType: 'INT_64',
-                  },
-                  value: {
-                    arguments: [
-                      {
-                        tag: 'INT_64',
-                        int64Val: '128',
-                      },
-                    ],
-                  },
-                },
-              },
-              {
-                tag: 'CONSTANT_TYPE',
-                constantType: {
-                  relType: {
-                    tag: 'PRIMITIVE_TYPE',
-                    primitiveType: 'INT_64',
-                  },
-                  value: {
-                    arguments: [
-                      {
-                        tag: 'INT_64',
-                        int64Val: '10',
-                      },
-                    ],
-                  },
-                },
-              },
-              {
-                tag: 'PRIMITIVE_TYPE',
-                primitiveType: 'INT_128',
-              },
-            ],
-          },
-        },
       ],
     }),
   };
-
   const specialRelation: ArrowRelation = {
     relationId: '/Int64(1)/:foo',
     table: tableFromArrays({}),
@@ -281,21 +172,20 @@ describe('ResultTable', () => {
         },
         { type: 'Char' },
         { type: 'Int64' },
-        { type: 'Decimal128', places: 10 },
       ]);
     });
 
     it('should get column length', () => {
       const table = new ResultTable(relation);
 
-      expect(table.columnLength).toEqual(7);
+      expect(table.columnLength).toEqual(6);
     });
 
     it('should get columns', () => {
       const table = new ResultTable(relation);
       const columns = table.columns();
 
-      expect(columns.length).toEqual(7);
+      expect(columns.length).toEqual(6);
       expect(columns[0].typeDef).toEqual({
         type: 'Constant',
         value: { type: 'Int64', value: 1n },
@@ -317,8 +207,6 @@ describe('ResultTable', () => {
       expect(columns[4].length).toEqual(4);
       expect(columns[5].typeDef).toEqual({ type: 'Int64' });
       expect(columns[5].length).toEqual(4);
-      expect(columns[6].typeDef).toEqual({ type: 'Decimal128', places: 10 });
-      expect(columns[6].length).toEqual(4);
     });
 
     it('should get column by index', () => {
@@ -394,7 +282,6 @@ describe('ResultTable', () => {
         [':bar', ':bar', ':bar', ':bar'],
         ['a', 'b', 'c', 'd'],
         [1n, 2n, 3n, 4n],
-        [MAX_DEC_128, MAX_DEC_128, MAX_DEC_128, MAX_DEC_128],
       ];
       expectedValues.forEach((expectedVals, index) => {
         expectedVals.forEach((val, valueIndex) => {
@@ -432,10 +319,10 @@ describe('ResultTable', () => {
         [1n, ':foo', 'z'],
       ]);
       expect(table.sliceColumns(4).values()).toEqual([
-        ['a', 1n, MAX_DEC_128],
-        ['b', 2n, MAX_DEC_128],
-        ['c', 3n, MAX_DEC_128],
-        ['d', 4n, MAX_DEC_128],
+        ['a', 1n],
+        ['b', 2n],
+        ['c', 3n],
+        ['d', 4n],
       ]);
       expect(table.sliceColumns(2, 4).values()).toEqual([
         ['w', ':bar'],
@@ -454,10 +341,10 @@ describe('ResultTable', () => {
     it('should be able to iterate table values', () => {
       const table = new ResultTable(relation);
       const expectedValues = [
-        [1n, ':foo', 'w', ':bar', 'a', 1n, MAX_DEC_128],
-        [1n, ':foo', 'x', ':bar', 'b', 2n, MAX_DEC_128],
-        [1n, ':foo', 'y', ':bar', 'c', 3n, MAX_DEC_128],
-        [1n, ':foo', 'z', ':bar', 'd', 4n, MAX_DEC_128],
+        [1n, ':foo', 'w', ':bar', 'a', 1n],
+        [1n, ':foo', 'x', ':bar', 'b', 2n],
+        [1n, ':foo', 'y', ':bar', 'c', 3n],
+        [1n, ':foo', 'z', ':bar', 'd', 4n],
       ];
 
       let i = 0;
@@ -471,10 +358,10 @@ describe('ResultTable', () => {
     it('should get table values', () => {
       const table = new ResultTable(relation);
       const expectedValues = [
-        [1n, ':foo', 'w', ':bar', 'a', 1n, MAX_DEC_128],
-        [1n, ':foo', 'x', ':bar', 'b', 2n, MAX_DEC_128],
-        [1n, ':foo', 'y', ':bar', 'c', 3n, MAX_DEC_128],
-        [1n, ':foo', 'z', ':bar', 'd', 4n, MAX_DEC_128],
+        [1n, ':foo', 'w', ':bar', 'a', 1n],
+        [1n, ':foo', 'x', ':bar', 'b', 2n],
+        [1n, ':foo', 'y', ':bar', 'c', 3n],
+        [1n, ':foo', 'z', ':bar', 'd', 4n],
       ];
 
       expect(table.values()).toEqual(expectedValues);
@@ -483,31 +370,23 @@ describe('ResultTable', () => {
     it('should get values by index', () => {
       const table = new ResultTable(relation);
 
-      expect(table.get(2)).toEqual([
-        1n,
-        ':foo',
-        'y',
-        ':bar',
-        'c',
-        3n,
-        MAX_DEC_128,
-      ]);
+      expect(table.get(2)).toEqual([1n, ':foo', 'y', ':bar', 'c', 3n]);
     });
 
     it('should slice table', () => {
       const table = new ResultTable(relation);
 
       expect(table.slice(undefined, 2).values()).toEqual([
-        [1n, ':foo', 'w', ':bar', 'a', 1n, MAX_DEC_128],
-        [1n, ':foo', 'x', ':bar', 'b', 2n, MAX_DEC_128],
+        [1n, ':foo', 'w', ':bar', 'a', 1n],
+        [1n, ':foo', 'x', ':bar', 'b', 2n],
       ]);
       expect(table.slice(2).values()).toEqual([
-        [1n, ':foo', 'y', ':bar', 'c', 3n, MAX_DEC_128],
-        [1n, ':foo', 'z', ':bar', 'd', 4n, MAX_DEC_128],
+        [1n, ':foo', 'y', ':bar', 'c', 3n],
+        [1n, ':foo', 'z', ':bar', 'd', 4n],
       ]);
       expect(table.slice(1, 3).values()).toEqual([
-        [1n, ':foo', 'x', ':bar', 'b', 2n, MAX_DEC_128],
-        [1n, ':foo', 'y', ':bar', 'c', 3n, MAX_DEC_128],
+        [1n, ':foo', 'x', ':bar', 'b', 2n],
+        [1n, ':foo', 'y', ':bar', 'c', 3n],
       ]);
     });
 
@@ -537,10 +416,10 @@ describe('ResultTable', () => {
       const physicalTable = table.physical();
 
       expect(physicalTable.values()).toEqual([
-        ['w', 'a', 1n, MAX_DEC_128],
-        ['x', 'b', 2n, MAX_DEC_128],
-        ['y', 'c', 3n, MAX_DEC_128],
-        ['z', 'd', 4n, MAX_DEC_128],
+        ['w', 'a', 1n],
+        ['x', 'b', 2n],
+        ['y', 'c', 3n],
+        ['z', 'd', 4n],
       ]);
     });
 

--- a/src/results/resultUtils.ts
+++ b/src/results/resultUtils.ts
@@ -29,7 +29,8 @@ import {
   ValueTypeValue,
 } from './types';
 
-Decimal.config({ precision: 31 });
+// Maximum number of precision digits in decimal128 is 39.
+Decimal.config({ precision: 40 });
 
 // Rata Die milliseconds for 1970-01-01T00:00:00.
 // Date and DateTime types are represented as days and milliseconds

--- a/src/results/tests.ts
+++ b/src/results/tests.ts
@@ -486,15 +486,15 @@ export const standardTypeTests: Test[] = [
   },
   {
     name: 'Decimal128',
-    query: `def output = parse_decimal[128, 2, "12345678901011121314.34"]`,
+    query: `def output = parse_decimal[128, 2, "123456789010111213141516171819202122.34"]`,
     typeDefs: [
       {
         type: 'Decimal128',
         places: 2,
       },
     ],
-    values: [new Decimal('12345678901011121314.34')],
-    displayValues: ['12345678901011121314.34'],
+    values: [new Decimal('123456789010111213141516171819202122.34')],
+    displayValues: ['123456789010111213141516171819202122.34'],
   },
   {
     name: 'Rational8',
@@ -1281,7 +1281,7 @@ export const specializationTests: Test[] = [
   {
     name: 'Decimal128',
     query: `
-      def v = parse_decimal[128, 2, "12345678901011121314.34"]
+      def v = parse_decimal[128, 2, "123456789010111213141516171819202122.34"]
       def output = #(v)
     `,
     typeDefs: [
@@ -1289,13 +1289,13 @@ export const specializationTests: Test[] = [
         type: 'Constant',
         value: {
           type: 'Decimal128',
-          value: new Decimal('12345678901011121314.34'),
+          value: new Decimal('123456789010111213141516171819202122.34'),
           places: 2,
         },
       },
     ],
-    values: [new Decimal('12345678901011121314.34')],
-    displayValues: ['12345678901011121314.34'],
+    values: [new Decimal('123456789010111213141516171819202122.34')],
+    displayValues: ['123456789010111213141516171819202122.34'],
   },
   {
     name: 'Rational8',
@@ -2398,7 +2398,7 @@ export const valueTypeTests: Test[] = [
     name: 'Decimal128',
     query: `
       value type MyType = Int, FixedDecimal[128, 2]
-      def output = ^MyType[1, parse_decimal[128, 2, "12345678901011121314.34"]]
+      def output = ^MyType[1, parse_decimal[128, 2, "123456789010111213141516171819202122.34"]]
     `,
     typeDefs: [
       {
@@ -2418,8 +2418,10 @@ export const valueTypeTests: Test[] = [
         ],
       },
     ],
-    values: [[':MyType', 1n, new Decimal('12345678901011121314.34')]],
-    displayValues: ['(:MyType, 1, 12345678901011121314.34)'],
+    values: [
+      [':MyType', 1n, new Decimal('123456789010111213141516171819202122.34')],
+    ],
+    displayValues: ['(:MyType, 1, 123456789010111213141516171819202122.34)'],
   },
   {
     name: 'Rational8',
@@ -3932,7 +3934,7 @@ export const valueTypeSpecializationTests: Test[] = [
     name: 'Decimal128',
     query: `
       value type MyType = FixedDecimal[128, 2], Int
-      def v = ^MyType[parse_decimal[128, 2, "12345678901011121314.34"], 1]
+      def v = ^MyType[parse_decimal[128, 2, "123456789010111213141516171819202122.34"], 1]
       def output = #(v)
     `,
     typeDefs: [
@@ -3953,12 +3955,18 @@ export const valueTypeSpecializationTests: Test[] = [
               type: 'Int64',
             },
           ],
-          value: [':MyType', new Decimal('12345678901011121314.34'), 1n],
+          value: [
+            ':MyType',
+            new Decimal('123456789010111213141516171819202122.34'),
+            1n,
+          ],
         },
       },
     ],
-    values: [[':MyType', new Decimal('12345678901011121314.34'), 1n]],
-    displayValues: ['(:MyType, 12345678901011121314.34, 1)'],
+    values: [
+      [':MyType', new Decimal('123456789010111213141516171819202122.34'), 1n],
+    ],
+    displayValues: ['(:MyType, 123456789010111213141516171819202122.34, 1)'],
   },
   {
     name: 'Rational8',


### PR DESCRIPTION
Fixes [RAI-15919](https://relationalai.atlassian.net/browse/RAI-15919) by bumping decimal.js precision to 40, since decimal128 maximum precision digits is 39 (2^127)

[RAI-15919]: https://relationalai.atlassian.net/browse/RAI-15919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ