### PR TITLE
Remove auto_number test

### DIFF
--- a/src/results/tests.ts
+++ b/src/results/tests.ts
@@ -577,20 +577,6 @@ export const standardTypeTests: Test[] = [
     displayValues: ['123456789101112313/9123456789101112313'],
   },
   {
-    name: 'AutoNumber',
-    query: `
-      def num = auto_number["a"]
-      def output(x) = num(_, x) 
-    `,
-    typeDefs: [
-      {
-        type: 'AutoNumber',
-      },
-    ],
-    values: [1n],
-    displayValues: ['1'],
-  },
-  {
     name: 'UUID',
     query: `
       with rel:base use uuid_from_string


### PR DESCRIPTION
In next week's release we are going to remove the long deprecated auto_number FFI as part of the surface area reduction initiative. This PR removes a test case that would break then.