### PR TITLE
Handle RAI returning float -0 as 0

### DIFF
--- a/src/results/tests.ts
+++ b/src/results/tests.ts
@@ -399,7 +399,7 @@ export const standardTypeTests: Test[] = [
   },
   {
     name: 'Float16',
-    query: `def output = float[16, 12], float[16, 42.5], float[16, -0.0]`,
+    query: `def output = float[16, 12], float[16, 42.5], float[16, 0.0]`,
     typeDefs: [
       {
         type: 'Float16',
@@ -416,7 +416,7 @@ export const standardTypeTests: Test[] = [
   },
   {
     name: 'Float32',
-    query: `def output = float[32, 12], float[32, 42.5], float[32, -0.0]`,
+    query: `def output = float[32, 12], float[32, 42.5], float[32, 0.0]`,
     typeDefs: [
       {
         type: 'Float32',
@@ -433,7 +433,7 @@ export const standardTypeTests: Test[] = [
   },
   {
     name: 'Float64',
-    query: `def output = float[64, 12], float[64, 42.5], float[64, -0.0]`,
+    query: `def output = float[64, 12], float[64, 42.5], float[64, 0.0]`,
     typeDefs: [
       {
         type: 'Float64',

--- a/src/results/tests.ts
+++ b/src/results/tests.ts
@@ -411,8 +411,8 @@ export const standardTypeTests: Test[] = [
         type: 'Float16',
       },
     ],
-    values: [12, 42.5, -0],
-    displayValues: ['12.0', '42.5', '-0.0'],
+    values: [12, 42.5, 0],
+    displayValues: ['12.0', '42.5', '0.0'],
   },
   {
     name: 'Float32',
@@ -428,8 +428,8 @@ export const standardTypeTests: Test[] = [
         type: 'Float32',
       },
     ],
-    values: [12, 42.5, -0],
-    displayValues: ['12.0', '42.5', '-0.0'],
+    values: [12, 42.5, 0],
+    displayValues: ['12.0', '42.5', '0.0'],
   },
   {
     name: 'Float64',
@@ -445,8 +445,8 @@ export const standardTypeTests: Test[] = [
         type: 'Float64',
       },
     ],
-    values: [12, 42.5, -0],
-    displayValues: ['12.0', '42.5', '-0.0'],
+    values: [12, 42.5, 0],
+    displayValues: ['12.0', '42.5', '0.0'],
   },
   {
     name: 'Decimal16',


### PR DESCRIPTION
RAI will soon return float -0 as 0 (see https://github.com/RelationalAI/raicode/pull/19373).
This changes some tests that expect -0 to be returned. Since the change to RAI isn't merged yet, this just changes the tests to return 0 instead of -0.