### PR TITLE
 Fix 4 High Dependabot alerts (fast-uri, js-yaml, brace-expansion)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2614,10 +2614,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4917,9 +4918,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -8183,10 +8184,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -108,5 +108,10 @@
     "ini": "5.0.0",
     "node-fetch-commonjs": "3.2.4",
     "query-string": "7.1.0"
+  },
+  "overrides": {
+    "fast-uri": "3.1.4",
+    "js-yaml": "3.15.0",
+    "brace-expansion": "1.1.17"
   }
 }


### PR DESCRIPTION
### PR Description

Fixes 4 High Dependabot alerts via new npm `overrides` (no code changes):

- **brace-expansion** — [RAI-52913](https://relationalai.atlassian.net/browse/RAI-52913) — new override → 1.1.17
- **js-yaml** — [RAI-52834](https://relationalai.atlassian.net/browse/RAI-52834) — new override → 3.15.0
- **fast-uri** (2 CVEs — host confusion) — [RAI-52808](https://relationalai.atlassian.net/browse/RAI-52808), [RAI-52807](https://relationalai.atlassian.net/browse/RAI-52807) — new override → 3.1.4

All three are single-instance devDependency/tooling deps (eslint, jest, webpack chains) — no runtime code paths touch them, and each override is a blanket bump since there's no conflicting version requirement elsewhere in the tree.

Verified: `npm ci` resolves clean, `npm audit` no longer flags any of the 4 target GHSAs, `tscheck`/`build`/`lint` all pass.

Note: `yarn.lock` exists in the repo but CI only runs `npm ci` — left untouched as it appears unused/stale.

Closes RAI-52913, RAI-52834, RAI-52808, RAI-52807

### Review Guidelines

Small diff — just `package.json` (`overrides` field) + `package-lock.json`.

### Checklist

- [x] My PR is covered by existing test cases, or includes at least basic test cases
- [x] I have removed all dead code, debug statements, and PR-specific TODOs
- [x] I have introduced sufficient documentation to the READMEs, or determined that no documentation is needed.


[RAI-52913]: https://relationalai.atlassian.net/browse/RAI-52913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAI-52834]: https://relationalai.atlassian.net/browse/RAI-52834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAI-52808]: https://relationalai.atlassian.net/browse/RAI-52808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAI-52807]: https://relationalai.atlassian.net/browse/RAI-52807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ